### PR TITLE
checkbox，radio视觉走查问题

### DIFF
--- a/packages/react-impression/src/components/Checkbox/README.md
+++ b/packages/react-impression/src/components/Checkbox/README.md
@@ -61,7 +61,7 @@ class Indeterminate extends React.Component {
   render() {
     return (
       <div>
-        <div className="offset-b-lg">
+        <div className="offset-b">
           <Checkbox
             indeterminate={this.state.indeterminate}
             onChange={this.onCheckAllChange}
@@ -91,11 +91,3 @@ class Indeterminate extends React.Component {
 v2.0.0
 
 * 新增 indeterminate 参数
-* 新增 sass 变量`$checkbox-addon-size`表示 Checkbox 尺寸
-* 新增 sass 变量`$checkbox-addon-bg-color`表示 Checkbox 背景色
-* 新增 sass 变量`$checkbox-addon-border-width`表示 Checkbox 边框宽度
-* 新增 sass 变量`$checkbox-addon-border-color`表示 Checkbox 未选中边框色
-* 新增 sass 变量`$checkbox-addon-checked-color`表示 Checkbox 选中色
-* 新增 sass 变量`$checkbox-addon-disabled-color`表示 Checkbox 禁用色
-* 新增 sass 变量`$checkbox-addon-scale`表示 Checkbox 中间图标缩放比例
-* 更改 sass 变量`$checkbox-addon-width`、`$checkbox-addon-height`为 `$checkbox-addon-i-size` 表示 Checkbox 中间图标尺寸

--- a/packages/react-impression/src/components/Radio/README.md
+++ b/packages/react-impression/src/components/Radio/README.md
@@ -20,15 +20,3 @@
   </Col>
 </Row>
 ```
-
-### 变更记录
-
-v2.0.0
-
-* 新增 sass 变量`$radio-addon-size`表示 Radio 尺寸
-* 新增 sass 变量`$radio-addon-bg-color`表示 Radio 背景色
-* 新增 sass 变量`$radio-addon-border-width`表示 Radio 边框宽度
-* 新增 sass 变量`$radio-addon-border-color`表示 Radio 未选中边框色
-* 新增 sass 变量`$radio-addon-checked-color`表示 Radio 选中色
-* 新增 sass 变量`$radio-addon-disabled-color`表示 Radio 禁用色
-* 更改 sass 变量`$radio-addon-width`、`$radio-addon-height`为 `$radio-addon-i-size` 表示 Radio 中间圆点尺寸

--- a/packages/react-impression/src/styles/modules/_checkbox.scss
+++ b/packages/react-impression/src/styles/modules/_checkbox.scss
@@ -1,129 +1,119 @@
 // checkbox
 .checkbox {
-    position: relative;
-    display: inline-block;
-    margin: 0;
-    font-weight: normal !important;
-    cursor: pointer;
-    user-select: none;
-    vertical-align: middle;
+  position: relative;
+  display: inline-block;
+  margin: 0;
+  font-weight: normal !important;
+  cursor: pointer;
+  user-select: none;
+  vertical-align: middle;
+  input {
+    position: absolute;
+    z-index: -1;
+    top: 0;
+    left: 0;
+    visibility: hidden;
 
-    input {
-        visibility: hidden;
+    &:checked + .checkbox-addon {
+      border-color: $checkbox-addon-checked-color;
+      i {
+        transform: scale(1);
+        color: $checkbox-addon-checked-color;
+      }
     }
-}
 
-.checkbox-label,
-.radio-label {
-    user-select: none;
-    vertical-align: middle;
-
-    &:not(:empty) {
-        margin-left: $checkbox-label-space-x;
+    &:disabled + .checkbox-addon {
+      cursor: not-allowed;
+      border-color: $checkbox-addon-disabled-color;
+      i {
+        color: $checkbox-addon-disabled-color;
+      }
+      & + .checkbox-label {
+        cursor: not-allowed;
+        color: $checkbox-addon-disabled-color;
+      }
     }
-}
 
-.checkbox-inline,
-.radio-inline {
-    display: inline-block;
-    user-select: none;
-
-    .checkbox:not(:last-child),
-    .radio:not(:last-child) {
-        margin-right: $checkbox-space-x;
+    &:not(:checked):not(:disabled) + .checkbox-addon:hover {
+      border-color: $checkbox-addon-checked-color;
     }
-}
+  }
 
-.checkbox-vertical,
-.radio-vertical {
-    display: block;
-    user-select: none;
+  @at-root #{&}-indeterminate {
+    .checkbox-addon {
+      width: $checkbox-addon-padding * 2 + 4 + round($checkbox-addon-i-size * $font-size-root); // padding + border + i标签的宽高
+      height: $checkbox-addon-padding * 2 + 4 + round($checkbox-addon-i-size * $font-size-root);
+      border-color: $checkbox-addon-checked-color;
 
-    .checkbox:not(:last-child),
-    .radio:not(:last-child) {
+      &::before {
+        position: relative;
+        top: 50%;
         display: block;
-        margin-bottom: $checkbox-space-x;
+        margin-top: -$border-width;
+        content: "";
+        border: $border-width solid $checkbox-addon-indeterminate-color;
+      }
+
+      i {
+        display: none;
+      }
     }
+    input:disabled + .checkbox-addon::before {
+      border-color: $checkbox-addon-disabled-color;
+    }
+  }
 }
+.checkbox-label {
+  user-select: none;
+  vertical-align: middle;
 
-.checkbox {
-    input {
-        position: absolute;
-        z-index: -1;
-        top: 0;
-        left: 0;
+  &:not(:empty) {
+    padding-left: $checkbox-label-space-x;
+  }
+}
+.checkbox-inline {
+  display: inline-block;
+  user-select: none;
 
-        &:checked + .checkbox-addon {
-            border-color: $checkbox-addon-checked-color;
-            i {
-                transform: scale(1);
-                color: $checkbox-addon-checked-color;
-            }
-        }
+  .checkbox:not(:last-child) {
+    margin-right: $checkbox-space-x;
+  }
+}
+.checkbox-vertical {
+  display: block;
+  user-select: none;
 
-        &:disabled + .checkbox-addon {
-            border-color: $checkbox-addon-disabled-color;
-            i {
-                color: $checkbox-addon-disabled-color;
-            }
-        }
-
-        &:not(:checked):not(:disabled) + .checkbox-addon:hover {
-            border-color: $checkbox-addon-checked-color;
-        }
-    }
-
-    @at-root #{&}-indeterminate {
-        .checkbox-addon {
-            width: $checkbox-addon-padding * 2 + 4 + round($checkbox-addon-i-size * $font-size-root); // padding + border + i标签的宽高
-            height: $checkbox-addon-padding * 2 + 4 + round($checkbox-addon-i-size * $font-size-root);
-            border-color: $checkbox-addon-checked-color;
-
-            &::before {
-                position: relative;
-                top: 50%;
-                display: block;
-                margin-top: -$border-width;
-                content: "";
-                border: $border-width solid $checkbox-addon-indeterminate-color;
-            }
-
-            i {
-                display: none;
-            }
-        }
-
-        input:disabled + .checkbox-addon::before {
-            border-color: $checkbox-addon-disabled-color;
-        }
-    }
+  .checkbox:not(:last-child) {
+    display: block;
+    margin-bottom: $checkbox-space-x;
+  }
 }
 .checkbox-addon {
-    position: relative;
-    display: inline-block;
-    padding: $checkbox-addon-padding;
-    line-height: 1;
-    transition: $checkbox-addon-transtion;
-    vertical-align: middle;
-    border: $checkbox-addon-border-width solid $checkbox-addon-border-color;
-    border-radius: $checkbox-addon-border-radius;
-    background-color: $checkbox-addon-bg-color;
+  position: relative;
+  display: inline-block;
+  padding: $checkbox-addon-padding;
+  line-height: 1;
+  transition: $checkbox-addon-transtion;
+  vertical-align: middle;
+  border: $checkbox-addon-border-width solid $checkbox-addon-border-color;
+  border-radius: $checkbox-addon-border-radius;
+  background-color: $checkbox-addon-bg-color;
 
-    i {
-        position: relative;
-        display: block;
-        width: round($checkbox-addon-i-size * $font-size-root);
-        height: round($checkbox-addon-i-size * $font-size-root);
-        transition: $checkbox-addon-transtion;
-        transform: scale(0);
-        transform-origin: 50% 50%;
-        color: transparent;
-        &::before {
-            position: absolute;
-            top: round(($checkbox-addon-scale - 1) / 2 * $font-size-root);
-            left: round(($checkbox-addon-scale - 1) / 2 * $font-size-root);
-            display: block;
-            transform: scale($checkbox-addon-scale);
-        }
+  i {
+    position: relative;
+    display: block;
+    width: round($checkbox-addon-i-size * $font-size-root);
+    height: round($checkbox-addon-i-size * $font-size-root);
+    transition: $checkbox-addon-transtion;
+    transform: scale(0);
+    transform-origin: 50% 50%;
+    color: transparent;
+    &::before {
+      position: absolute;
+      top: round(($checkbox-addon-scale - 1) / 2 * $font-size-root);
+      left: round(($checkbox-addon-scale - 1) / 2 * $font-size-root);
+      display: block;
+      transform: scale($checkbox-addon-scale);
     }
+  }
 }

--- a/packages/react-impression/src/styles/modules/_radio.scss
+++ b/packages/react-impression/src/styles/modules/_radio.scss
@@ -1,60 +1,89 @@
 // radio
 .radio {
-    position: relative;
-    display: inline-block;
-    margin: 0;
-    font-weight: normal !important;
-    cursor: pointer;
-    user-select: none;
-    vertical-align: middle;
-    input {
-        position: absolute;
-        z-index: -1;
-        top: 0;
-        left: 0;
-        visibility: hidden;
+  position: relative;
+  display: inline-block;
+  margin: 0;
+  font-weight: normal !important;
+  cursor: pointer;
+  user-select: none;
+  vertical-align: middle;
+  input {
+    position: absolute;
+    z-index: -1;
+    top: 0;
+    left: 0;
+    visibility: hidden;
 
-        &:checked + .radio-addon {
-            border-color: $radio-addon-checked-color;
-            i {
-                transform: scale(1);
-                background-color: $radio-addon-checked-color;
-            }
-        }
-
-        &:disabled + .radio-addon {
-            border-color: $radio-addon-disabled-color;
-            i {
-                background-color: $radio-addon-disabled-color;
-            }
-        }
-
-        &:not(:checked):not(:disabled) + .radio-addon:hover {
-            opacity: .8;
-            border-color: $radio-addon-checked-color;
-        }
+    &:checked + .radio-addon {
+      border-color: $radio-addon-checked-color;
+      i {
+        transform: scale(1);
+        background-color: $radio-addon-checked-color;
+      }
     }
+
+    &:disabled + .radio-addon {
+      cursor: not-allowed;
+      border-color: $radio-addon-disabled-color;
+      i {
+        background-color: $radio-addon-disabled-color;
+      }
+      & + .radio-label {
+        cursor: not-allowed;
+        color: $radio-addon-disabled-color;
+      }
+    }
+
+    &:not(:checked):not(:disabled) + .radio-addon:hover {
+      opacity: .8;
+      border-color: $radio-addon-checked-color;
+    }
+  }
 }
+.radio-label {
+  user-select: none;
+  vertical-align: middle;
 
+  &:not(:empty) {
+    padding-left: $radio-label-space-x;
+  }
+}
+.radio-inline {
+  display: inline-block;
+  user-select: none;
+
+  .radio:not(:last-child) {
+    margin-right: $radio-space-x;
+  }
+}
+.radio-vertical {
+  display: block;
+  user-select: none;
+
+  .radio:not(:last-child) {
+    display: block;
+    margin-bottom: $radio-space-x;
+  }
+}
 .radio-addon {
-    position: relative;
-    display: inline-block;
-    padding: $radio-addon-padding;
-    transition: $checkbox-addon-transtion;
-    vertical-align: middle;
-    border: $radio-addon-border-width solid $radio-addon-border-color;
-    border-radius: 50%;
-    background-color: $radio-addon-bg-color;
+  position: relative;
+  display: inline-block;
+  padding: $radio-addon-padding;
+  transition: $radio-addon-transtion;
+  vertical-align: middle;
+  border: $radio-addon-border-width solid $radio-addon-border-color;
+  border-radius: 50%;
+  background-color: $radio-addon-bg-color;
 
-    i {
-        display: block;
-        width: round($radio-addon-i-size * $font-size-root);
-        height: round($radio-addon-i-size * $font-size-root);
-        content: "";
-        transition: $checkbox-addon-transtion;
-        transform: scale(0);
-        transform-origin: 50% 50%;
-        border-radius: 50%;
-        background: transparent;
-    }
+  i {
+    display: block;
+    width: round($radio-addon-i-size * $font-size-root);
+    height: round($radio-addon-i-size * $font-size-root);
+    content: "";
+    transition: $radio-addon-transtion;
+    transform: scale(0);
+    transform-origin: 50% 50%;
+    border-radius: 50%;
+    background: transparent;
+  }
 }

--- a/packages/react-impression/src/styles/variables/_body.scss
+++ b/packages/react-impression/src/styles/variables/_body.scss
@@ -1,5 +1,5 @@
 // Body
 $body-bg: $brand-pure !default;
-$body-color: #666 !default;
+$body-color: $gray-base !default;
 $border-color: $gray-light !default;
 $text-muted: $gray-darker !default;

--- a/packages/react-impression/src/styles/variables/_checkbox.scss
+++ b/packages/react-impression/src/styles/variables/_checkbox.scss
@@ -1,13 +1,12 @@
 //== Checkbox
-$checkbox-label-space-x:                    $spacer-y / 2 !default;
-$checkbox-space-x:                          $spacer-y !default;
-$checkbox-space-y:                          $spacer-y !default;
+$checkbox-label-space-x:                    rem(10px) !default;
+$checkbox-space-x:                          rem(50px) !default;
 $checkbox-addon-size:                       1.28 !default;
 $checkbox-addon-i-size:                     .7 !default;
 $checkbox-addon-padding:                    round(($checkbox-addon-size - $checkbox-addon-i-size) * $font-size-root / 2 - 1) !default;
 $checkbox-addon-border-color:               $gray-darker !default;
 $checkbox-addon-border-width:               rem(2px) !default;
-$checkbox-addon-border-radius:              rem(2px) !default;
+$checkbox-addon-border-radius:              $border-radius !default;
 $checkbox-addon-transtion:                  all .2s ease !default;
 $checkbox-addon-bg-color:                   $brand-pure !default;
 $checkbox-addon-checked-color:              $brand-primary !default;

--- a/packages/react-impression/src/styles/variables/_radio.scss
+++ b/packages/react-impression/src/styles/variables/_radio.scss
@@ -1,4 +1,7 @@
 //== Radio
+$radio-label-space-x:                       rem(10px) !default;
+$radio-space-x:                             rem(50px) !default;
+
 $radio-addon-size:                          1.28 !default;
 $radio-addon-i-size:                        .4 !default;
 $radio-addon-padding:                       round(($radio-addon-size - $radio-addon-i-size) * $font-size-root / 2 - 1) !default;
@@ -7,3 +10,4 @@ $radio-addon-border-color:                  $gray-darker !default;
 $radio-addon-border-width:                  rem(2px) !default;
 $radio-addon-checked-color:                 $brand-primary !default;
 $radio-addon-disabled-color:                $gray !default;
+$radio-addon-transtion:                     all .2s ease !default;


### PR DESCRIPTION
修复视觉走查问题：
1. checkbox，radio未禁用字体颜色
2. 禁用状态的字体颜色
3. 子项间距
4. 禁用状态cursor