### PR TITLE
F turn off swipeEasing to avoid Select error

### DIFF
--- a/packages/react-impression/src/components/Select/Select.js
+++ b/packages/react-impression/src/components/Select/Select.js
@@ -465,6 +465,7 @@ export default class Select extends React.PureComponent {
       this.selectInner.scrollTop = 0
       this.selectScrollbar = new PerfectScrollbar(this.selectInner, {
         suppressScrollX: true,
+        swipeEasing: false,
       })
     })
   }

--- a/packages/react-impression/src/components/SidebarBody/SidebarBody.js
+++ b/packages/react-impression/src/components/SidebarBody/SidebarBody.js
@@ -24,6 +24,7 @@ export default class SidebarBody extends React.PureComponent {
     setTimeout(() => {
       this.scrollbar = new PerfectScrollbar(this.container, {
         suppressScrollX: true,
+        swipeEasing: false,
       })
     }, 1000)
   }

--- a/packages/react-impression/src/components/TimeSelect/TimeSelect.js
+++ b/packages/react-impression/src/components/TimeSelect/TimeSelect.js
@@ -45,17 +45,20 @@ export default class TimeSelect extends React.PureComponent {
     window.requestAnimationFrame(() => {
       this.hoursScrollbar = new PerfectScrollbar(this.hourContainer, {
         suppressScrollX: true,
+        swipeEasing: false,
         mixScrollbarLength: 34,
         maxScrollbarLength: 34,
       })
       this.minuteScrollbar = new PerfectScrollbar(this.minuteContainer, {
         suppressScrollX: true,
+        swipeEasing: false,
         mixScrollbarLength: 34,
         maxScrollbarLength: 34,
       })
       if (type === 'second') {
         this.secondScrollbar = new PerfectScrollbar(this.secondContainer, {
           suppressScrollX: true,
+          swipeEasing: false,
           mixScrollbarLength: 34,
           maxScrollbarLength: 34,
         })


### PR DESCRIPTION
turn off swipeEasing to avoid Select error "Cannot read property 'scrollTop' of null" on mobile while easing scroll