### PR TITLE
[bf]table组件中的pagination组件透传属性

### DIFF
--- a/packages/react-impression/src/components/Table/Table.js
+++ b/packages/react-impression/src/components/Table/Table.js
@@ -591,6 +591,7 @@ export default class Table extends React.PureComponent {
     return (
       <div className='table-pagination text-center'>
         <Pagination
+          {...pagination}
           scope={pagination.scope ? pagination.scope : 4}
           onSelect={this.handlePaginationChange}
           totalPage={pagination.totalPage}


### PR DESCRIPTION
更改了table组件中的pagination组件，pagination组件支持了很多功能，比如跳页查询，显示总数，但是table组件中使用的pagination组件由于固定只传入了几个属性，所以无法使用这些功能；需要将table组件中pagination属性直接透传