### PR TITLE
fix icon和button组合样式问题

### DIFF
--- a/packages/react-impression/src/components/Button/Button.js
+++ b/packages/react-impression/src/components/Button/Button.js
@@ -26,6 +26,8 @@ const Button = React.forwardRef((props, ref) => {
     iconPosition,
     ...others
   } = props
+  // 为了兼容旧版属性，手动删除 outline
+  delete others.outline
   delete others.eventKey
 
   // 判断按钮是否为纯图标按钮：无children 或者 shape 为 circle
@@ -150,6 +152,12 @@ Button.propTypes = {
    * 按钮的位置
    */
   iconPosition: PropTypes.oneOf(['left', 'right']),
+
+  /**
+   * 按钮的位置 v2.1.2废弃
+   * @ignore
+   */
+  outline: PropTypes.bool,
 }
 Button.defaultProps = {
   theme: 'primary',

--- a/packages/react-impression/src/styles/modules/_buttons.scss
+++ b/packages/react-impression/src/styles/modules/_buttons.scss
@@ -5,9 +5,7 @@
 //
 
 .btn {
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
+  display: inline-block;
   white-space: nowrap;
   vertical-align: middle;
   cursor: pointer;
@@ -48,6 +46,10 @@
     &:hover {
       box-shadow: none;
     }
+  }
+
+  & > i {
+    vertical-align: top;
   }
 
   & > span {

--- a/packages/react-impression/src/styles/modules/_ico.scss
+++ b/packages/react-impression/src/styles/modules/_ico.scss
@@ -1,3 +1,7 @@
+.dada-ico {
+  display: inline-block;
+}
+
 .dada-ico-xs {
   font-size: $ico-size-xs;
 }


### PR DESCRIPTION
a标签嵌套Button组件时，因为Button组件display: inline-flex，导致hover效果出问题；
修改：Button组件display: inline-block；同时修改 Ico组件，即i标签的样式，解决 icon 和 button组合样式问题。